### PR TITLE
Fixed URLs and php 5.6 deprecated error

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,3 +1,7 @@
+# Disabling false deprecation error
+php_value always_populate_raw_post_data -1
+
+
 ############################################
 ## overrides deployment configuration mode value
 ## use command bin/magento deploy:mode:set to switch modes

--- a/build.xml
+++ b/build.xml
@@ -105,7 +105,7 @@
             <equals arg1="${magento.db.pass}" arg2="" />
             <then>
                 <exec command="${bin.magento} setup:install
-                    --base-url=http://www.magento2.dev/
+                    --base-url=http://localhost/
                     --db-host=${magento.db.host}
                     --db-name=${magento.db.name}
                     --db-user=${magento.db.user}
@@ -122,7 +122,7 @@
             </then>
             <else>
                 <exec command="${bin.magento} setup:install
-                    --base-url=http://www.magento2.dev/
+                    --base-url=http://localhost/
                     --db-host=${magento.db.host}
                     --db-name=${magento.db.name}
                     --db-user=${magento.db.user}

--- a/dev/tests/api-functional/phpunit.xml.dist
+++ b/dev/tests/api-functional/phpunit.xml.dist
@@ -35,7 +35,7 @@
         <!-- WebSerivice Type. Possible values: soap, rest -->
         <const name="TESTS_WEB_API_ADAPTER" value="rest"/>
         <!-- Webserver URL -->
-        <const name="TESTS_BASE_URL" value="http://magento.url"/>
+        <const name="TESTS_BASE_URL" value="http://localhost"/>
         <!-- Webserver API user -->
         <const name="TESTS_WEBSERVICE_USER" value="admin"/>
         <!-- Webserver API key -->


### PR DESCRIPTION
Changed some URLs to localhost to make the tests run properly and added a php_flag in the htaccess file to disable a false positive due to a deprecation in php 5.6